### PR TITLE
translation fix 3

### DIFF
--- a/YuEzTools/Resources/Languages/English.yaml
+++ b/YuEzTools/Resources/Languages/English.yaml
@@ -71,6 +71,7 @@ NowImpMoreThan: "The impostor number is larger than the game setting or 3\nThere
 NowHImpMoreThan: "The impostor number is larger than 1\nThere may be hackers or you joined a modded lobby"
 NotLogin: "is not logged in.\n[Ban logged out player] enabled - Trying to ban the player"
 unKickNotLogin: "is not logged in\n[Ban logged out player] is disabled"
+BlackList: "is on your YuET's blacklist"
 
 # MenuUI.Interface
 Interface: "Interface"
@@ -124,6 +125,8 @@ MenuUI.FPSPlus: "Unlock FPS Upperlimit"
 # VerShow
 VerShow.HasUpdate: "<color={0}>{1}</color> (<color=#DC143C>YuET has a new update：v{2}!</color>)"
 VerShow.HasNotUpdate: "<color={0}>{1}</color> (<color=#00FF00>Your YuET is up to date</color>)"
+VerShow.Visit: "<color=#483D8B>{1}</color> <color=#FF00FF> has been used <color=#191970>{2}</color> times~</color>"
+UsingVersion: "<color=#DC143C>[{2}]</color>"
 
 # FunctionPatch
 FunctionPatch.AbolishDownTimer: "Cancel Start Countdown"
@@ -176,3 +179,8 @@ ImpostorIntroText: "<color={0}>Evil is coming...</color>"
 
 # TaskText
 FakeTask: "Fake task is as follows:"
+
+# RoomList
+iPhone: "IOS"
+Android: "Android"
+Platforms.Unknown: "Unknown"


### PR DESCRIPTION
For iPhone translation, I put "IOS" in there because iPads count as an apple device too